### PR TITLE
add isZalgified function

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,11 @@
 
   <div class='container'>
     <div class="row">
-      <div class="input-field col s8">
+      <div class="input-field col s2">
+        <input type="checkbox" class="filled-in" id="on" checked="checked" />
+        <label for="on">Zalgify?</label>
+      </div>
+      <div class="input-field col s6">
         <input value="some string" id="string" type="text">
         <label for="string" class="tooltipped active" data-position="top"
                data-delay="50" data-tooltip="Enter a string to zalgify.">
@@ -51,10 +55,15 @@
       </div>
     </div>
     <div class='row'>
-      <div class='col s12'>
+      <div class='col s10'>
         <h2 id='result'></h2>
       </div>
+      <div class="input-field col s2">
+        <input type="checkbox" class="filled-in" id="is" checked="checked" />
+        <label for="is">is Zalgified?</label>
+      </div>
     </div>
+
   </div>
 
 </body>
@@ -66,14 +75,23 @@
 <script type="text/javascript">
   $(document).ready(function () {
     process();
-    $(".input-field").keyup(function () {
-      process();
-    });
+    $(" body ").keyup( function () { process(); });
+    $( "body" ).click( function () { process(); });
   });
 
   function process() {
-    var z = zalgify($('#string').val(), $('#frequency').val(), $('#intensity').val());
-    $('#result').html(z);
+    //if $on is checked, zalfigy
+    if( $('#on').is(':checked') ) { 
+      //perform zalgification
+      var z = zalgify($('#string').val(), $('#frequency').val(), $('#intensity').val());
+      //and print
+      $('#result').html(z);
+    } else {
+      //else, print the original string
+      $('#result').html($('#string').val());      
+    }
+    // assign $is based on truth value of isZalgified of result html
+    $('#is').prop('checked', isZalgified($('#result').html()) );
   }
 </script>
 

--- a/zalgify.js
+++ b/zalgify.js
@@ -10,8 +10,10 @@ var diacritics = [
 // flatten diacritics
 diacritics = [].concat.apply([], diacritics);
 
+//returns boolean on whether the word has been zalgified yet or not
 function isZalgified(string) {
-  // add stuff here
+  // console.log(escape(string[0]));
+  return (escape(string[0])=='%u200C');
 }
 
 function zalgify(string, frequency, intensity) {
@@ -30,6 +32,8 @@ function zalgify(string, frequency, intensity) {
     }
     string[i] = zalgified;
   }
+  // zero-width non-joiner
+  string.unshift('&zwnj;'); 
   return string.join('');
 }
 


### PR DESCRIPTION
— zalgified words now begin with the // zero-width non-joiner // unicode character, &zwnj; / %u200C. Doesn’t affect display but can be checked for.
— also, updated interface to reflect new function test
